### PR TITLE
Trailing slashes

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -93,10 +93,13 @@ function Articles() {
 A route map defines the routing structure of the application. It is created by passing a map of routes into the `asRouteMap` function:
 
 ```js
-asRouteMap({
-  route1: ...,
-  route2: ...,
-})
+asRouteMap(
+  {
+    route1: ...,
+    route2: ...,
+  },
+  { trailingSlash: true } // reverse route behavior, default is false
+)
 ```
 
 The rules of `asRouteMap` is a structure that is similar to the original structure with a few differences:
@@ -176,6 +179,18 @@ const map = asRouteMap({
 console.log(map.route1()) // "/route1"
 console.log(map.route1.route2({ route2: 'route2' })) // "/route1/route2"
 ```
+
+Note that you can force the reverse routes to have a trailing slash with the option `trailingSlash` set to `true`:
+
+```js
+asRouteMap(
+  {
+    ...
+  },
+  { trailingSlash: true }
+)
+```
+
 ---
 ---
 ## Matching

--- a/src/routeMap.d.ts
+++ b/src/routeMap.d.ts
@@ -1,9 +1,9 @@
-import type { Route, RouteMap, Narrowable, AsRouteMap, HandlerOf, ReturnTypeOf, ReturnTypesOf } from './types'
+import type { Route, RouteMap, Narrowable, AsRouteMap, HandlerOf, ReturnTypeOf, ReturnTypesOf, Config } from './types'
 
 export function asRouteMap<
   N extends Narrowable,
   T extends { [k: string]: N | T | [] }// & RouteMapInput
->(input: T): AsRouteMap<T>
+>(input: T, config?: Config): AsRouteMap<T>
 
 export function pick<
   A,

--- a/src/routeMap.js
+++ b/src/routeMap.js
@@ -15,8 +15,8 @@ import { callOrReturn, mapValues, throwError } from './utils'
 export const routeSymbol = Symbol('routeSymbol')
 export const routeMapSymbol = Symbol('routeMapSymbol')
 
-export function asRouteMap(map, language = undefined) {
-  const children = normalizeChildren(map, language)
+export function asRouteMap(map) {
+  const children = normalizeChildren(map)
   return {
     ...children,
     [routeMapSymbol]: { children }
@@ -137,18 +137,18 @@ function score(routeSegments) {
   )
 }
 
-function normalizeChildren(children, language, getParent = () => null, parentName = '') {
+function normalizeChildren(children, getParent = () => null, parentName = '') {
   return mapValues(children, (childOrPath, key) => {
     const route = typeof childOrPath === 'string' ? { path: childOrPath } : childOrPath
-    return normalize(route, language, getParent, parentName ? `${parentName}.${key}` : key)
+    return normalize(route, getParent, parentName ? `${parentName}.${key}` : key)
   })
 }
 
-function normalize(routeInput, language, getParent, name) {
+function normalize(routeInput, getParent, name) {
   const { path, data = undefined, ...children } = routeInput
   if (path === undefined) throw new Error(`No path found in ${JSON.stringify(routeInput)}`)
 
-  const normalizedChildren = normalizeChildren(children, language, () => route, name)
+  const normalizedChildren = normalizeChildren(children, () => route, name)
   const route = createRoute(name, path, data, normalizedChildren, getParent)
   return route
 }

--- a/src/routeMap.js
+++ b/src/routeMap.js
@@ -15,8 +15,8 @@ import { callOrReturn, mapValues, throwError } from './utils'
 export const routeSymbol = Symbol('routeSymbol')
 export const routeMapSymbol = Symbol('routeMapSymbol')
 
-export function asRouteMap(map) {
-  const children = normalizeChildren(map)
+export function asRouteMap(map, config = {}) {
+  const children = normalizeChildren(config, map)
   return {
     ...children,
     [routeMapSymbol]: { children }
@@ -137,24 +137,24 @@ function score(routeSegments) {
   )
 }
 
-function normalizeChildren(children, getParent = () => null, parentName = '') {
+function normalizeChildren(config, children, getParent = () => null, parentName = '') {
   return mapValues(children, (childOrPath, key) => {
     const route = typeof childOrPath === 'string' ? { path: childOrPath } : childOrPath
-    return normalize(route, getParent, parentName ? `${parentName}.${key}` : key)
+    return normalize(config, route, getParent, parentName ? `${parentName}.${key}` : key)
   })
 }
 
-function normalize(routeInput, getParent, name) {
+function normalize(config, routeInput, getParent, name) {
   const { path, data = undefined, ...children } = routeInput
   if (path === undefined) throw new Error(`No path found in ${JSON.stringify(routeInput)}`)
 
-  const normalizedChildren = normalizeChildren(children, () => route, name)
-  const route = createRoute(name, path, data, normalizedChildren, getParent)
+  const normalizedChildren = normalizeChildren(config, children, () => route, name)
+  const route = createRoute(config, name, path, data, normalizedChildren, getParent)
   return route
 }
 
-function createRoute(name, path, data, children, getParent) {
-  return withReverseRoute({
+function createRoute(config, name, path, data, children, getParent) {
+  return withReverseRoute(config, {
     ...children,
     toString() { return name },
     path,
@@ -167,13 +167,14 @@ function createRoute(name, path, data, children, getParent) {
   })
 }
 
-function withReverseRoute(route) {
+function withReverseRoute(config, route) {
+  const { trailingSlash = false } = config
   return Object.assign(reverseRoute, route)
 
   function reverseRoute(params = {}) {
     const parentPaths = getParents(route).map(x => x.path)
 
-    return [...parentPaths, route.path].reduce(
+    const resolvedPath = [...parentPaths, route.path].reduce(
       (base, path) => {
         const { language } = params
         const normalizedPath = normalizePath(path, language)
@@ -182,6 +183,8 @@ function withReverseRoute(route) {
       },
       ''
     )
+
+    return `${resolvedPath}${trailingSlash && !resolvedPath.endsWith('/')  ?  '/' : ''}`
   }
 }
 

--- a/src/routeMap.js
+++ b/src/routeMap.js
@@ -184,7 +184,7 @@ function withReverseRoute(config, route) {
       ''
     )
 
-    return `${resolvedPath}${trailingSlash && !resolvedPath.endsWith('/')  ?  '/' : ''}`
+    return `${resolvedPath}${trailingSlash && !resolvedPath.endsWith('/') ? '/' : ''}`
   }
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -57,3 +57,7 @@ type StringAsParams<A> =
   A extends `*` ? '*' :
   never
 type LanguageSupport = { language?: string }
+
+export type Config = {
+  trailingSlash?: boolean
+}


### PR DESCRIPTION
We want to allow trailing slashes to be the default when constructing reverse routes. In order to be backwards compatible we introduce it as an optional flag.