### PR TITLE
Prevent loss of state when transitioning

### DIFF
--- a/example/src/App.js
+++ b/example/src/App.js
@@ -25,17 +25,14 @@ function Page() {
   return (
     <div className={styles.componentPage}>
       <Navigation />
-      {transition((props, transitionLocation) => {
-        const isLeaving = location !== transitionLocation
-        return (
-          <animated.div className={styles.content} style={props}>
-            {isLeaving
-              ? <StaticLocationProvider location={transitionLocation} children={<Content />} />
-              : <Content />
-            }
-          </animated.div>
-        )
-      })}
+      {transition((props, transitionLocation) => (
+        <animated.div className={styles.content} style={props}>
+          <StaticLocationProvider location={transitionLocation} >
+            <Content />
+          </StaticLocationProvider>
+        </animated.div>
+      ))}
+
     </div>
   )
 }
@@ -90,6 +87,8 @@ function Article({ params: { id } }) {
   const { matchRoutes, matchRoute } = useRouting()
   const routes = routeMap.articles.article
 
+  const counter = useCounter()
+
   return (
     <div>
       <h1>Article {id}</h1>
@@ -98,6 +97,7 @@ function Article({ params: { id } }) {
         <Link to={routes.tab1({ id })}>Tab1</Link>
         <Link to={routes.tab2({ id })}>Tab2</Link>
       </div>
+      <h2>{counter}</h2>
       <div>
         {matchRoutes(
           [routes.main, 'Main content'],
@@ -108,6 +108,20 @@ function Article({ params: { id } }) {
       {matchRoute(routes.tab1, <div>Side bar for tab 1</div>)}
     </div>
   )
+}
+
+function useCounter() {
+  const [count, setCount] = React.useState(1)
+
+  React.useEffect(
+    () => {
+      const i = setInterval(() => setCount(x => x + 1), 1000)
+      return () => clearInterval(i)
+    },
+    []
+  )
+
+  return count
 }
 
 function NotFound({ params: { '*': path } }) {

--- a/src/routing.js
+++ b/src/routing.js
@@ -165,14 +165,16 @@ export function LocationProvider({
 
 export function StaticLocationProvider({ location, children }) {
   if (!location) throw new Error(`Your need to supply a location for the static location provider`)
+  const { location: locationLive } = React.useContext(locationAndLocationMatchContext)
 
-  const navigate = React.useCallback(
+  const navigateStatic = React.useCallback(
     () => { throw new Error('You can not navigate in a static location provider') },
     []
   )
+  const navigateLive = React.useContext(navigateContext)
 
   return <navigateContext.Provider
-    value={navigate}
+    value={location === locationLive ? navigateLive : navigateStatic}
     children={<LocationAndLocationMatchContext {...{ location, children} } />}
   />
 }


### PR DESCRIPTION
In the previous example state was lost because the render tree changed, resulting in an unmount/mount.

While moving the `StaticLocationProvider` to the outside fixes the problem it has the side effect of not being able to navigate from any of its children. The `StaticLocationProvider` was updated to allow for navigation if the location is equal to the current location.