### PR TITLE
feat(types): retain route data declaration chains

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kaliber/routing",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "main": "index.js",
   "sideEffects": false,
   "publishConfig": {

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,8 +8,11 @@ type RouteTypeMetadata<DataDeclarations extends readonly unknown[]> = {
   readonly [routeDataDeclarationsSymbol]: DataDeclarations,
 }
 
+/** Broad callable constraint; generated routes retain their exact parameter tuple. */
+type RouteCallable = (...parameters: any[]) => string
+
 export type RouteMap = { [routeMapSymbol]: any }
-export type Route = ReverseRoute & RouteProps & { [routeSymbol]: any }
+export type Route = RouteCallable & RouteProps & { [routeSymbol]: any }
 /** The root-to-route `data` declarations retained by `AsRouteMap`. */
 export type RouteDataDeclarations<R> =
   R extends RouteTypeMetadata<infer DataDeclarations> ? DataDeclarations : readonly []

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,8 +1,18 @@
 import { Expand } from './machinery/typescript-utils.ts'
 import type { routeSymbol, routeMapSymbol } from './routeMap.js'
 
+/** Carries route declarations through the generated type without adding runtime data. */
+declare const routeDataDeclarationsSymbol: unique symbol
+
+type RouteTypeMetadata<DataDeclarations extends readonly unknown[]> = {
+  readonly [routeDataDeclarationsSymbol]: DataDeclarations,
+}
+
 export type RouteMap = { [routeMapSymbol]: any }
 export type Route = ReverseRoute & RouteProps & { [routeSymbol]: any }
+/** The root-to-route `data` declarations retained by `AsRouteMap`. */
+export type RouteDataDeclarations<R> =
+  R extends RouteTypeMetadata<infer DataDeclarations> ? DataDeclarations : readonly []
 export type ReverseRoute = (params?: object) => string
 export type RouteProps = {
   data?: any,
@@ -31,37 +41,70 @@ export type ExtractLocaleParamName<T extends Config> =
     ? (string extends X ? 'language' : X)
     : never
 
-// declaring the types inside a function to prevent passing arround LocaleParamName
+// Keep LocaleParamName local instead of threading it through every helper.
 function asRouteMap<Input extends RouteInputChildren, LocaleParamName extends string>() {
 
   type AsRouteMap<Input extends RouteInputChildren> =
-    AsRouteChildren<Input, EmptyParams> &
+    AsRouteChildren<Input, EmptyParams, readonly []> &
     { [routeMapSymbol]: any }
 
-  type AsRouteChildren<Input extends RouteInputChildren, PreviousParams> =
-    { [K in keyof Input]: Expand<AsRoute<Input[K], PreviousParams & AsParams<Input[K]>>> }
+  type AsRouteChildren<
+    Input extends RouteInputChildren,
+    PreviousParams,
+    PreviousDataDeclarations extends readonly unknown[],
+  > = {
+    [K in keyof Input]: Expand<AsRoute<
+      Input[K],
+      PreviousParams & AsParams<Input[K]>,
+      PreviousDataDeclarations
+    >>
+  }
 
-  type AsRoute<Input, Params> =
+  type AsRoute<Input, Params, PreviousDataDeclarations extends readonly unknown[]> =
     AsReverseRoute<Params> & (
-      Input extends string ? AsRouteProps<{ path: Input, data: undefined }> :
-      Input extends RouteInputWithChildren ? AsRouteWithChildren<Input, Params> :
-      never
+      Input extends string
+        ? AsRouteProps<
+          { path: Input, data: undefined },
+          readonly [...PreviousDataDeclarations, undefined]
+        >
+        : Input extends RouteInputWithChildren
+          ? AsRouteWithChildren<Input, Params, PreviousDataDeclarations>
+          : never
     )
 
   type AsReverseRoute<Params> =
     keyof Params extends never ? () => string :
     (params: Expand<Params>) => string
 
-  type AsRouteWithChildren<Input extends RouteInputWithChildren, Params> =
-    AsRouteProps<Input> &
-    AsRouteChildren<Omit<Input, keyof RouteInputObject>, Params>
+  type AsRouteWithChildren<
+    Input extends RouteInputWithChildren,
+    Params,
+    PreviousDataDeclarations extends readonly unknown[],
+  > =
+    AsRouteProps<Input, DataDeclarationsWith<PreviousDataDeclarations, Input>> &
+    AsRouteChildren<
+      Omit<Input, keyof RouteInputObject>,
+      Params,
+      DataDeclarationsWith<PreviousDataDeclarations, Input>
+    >
 
-  type AsRouteProps<Input extends RouteInputObject> = {
+  type AsRouteProps<
+    Input extends RouteInputObject,
+    DataDeclarations extends readonly unknown[],
+  > = {
     path: Input['path'],
-    data: Input['data'],
+    data: OwnData<Input>,
     toString(): string,
     [routeSymbol]: any,
-  }
+  } & RouteTypeMetadata<DataDeclarations>
+
+  type DataDeclarationsWith<
+    PreviousDataDeclarations extends readonly unknown[],
+    Input extends RouteInputObject,
+  > = readonly [...PreviousDataDeclarations, OwnData<Input>]
+
+  type OwnData<Input extends RouteInputObject> =
+    'data' extends keyof Input ? Input['data'] : undefined
 
   type AsParams<Input> = (
     Input extends string ? { [K in PathAsParamNames<Input>]: string } :

--- a/tsconfig.types.json
+++ b/tsconfig.types.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "./src/types.ts",
+    "./type-tests/**/*.ts"
+  ],
+  "exclude": [
+    "./typescript/**/*"
+  ],
+  "compilerOptions": {
+    "checkJs": false,
+    "ignoreDeprecations": "6.0",
+    "skipLibCheck": true
+  }
+}

--- a/type-tests/route-data-declarations.ts
+++ b/type-tests/route-data-declarations.ts
@@ -1,0 +1,60 @@
+import type { AsRouteMap, RouteDataDeclarations } from '../src/types.ts'
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends
+  (<T>() => T extends B ? 1 : 2) ? true : false
+type Assert<T extends true> = T
+
+type ParentData = { parent: 'parent' }
+type LeafData = { leaf: 'leaf' }
+
+type TestRouteMap = AsRouteMap<{
+  root: ''
+  app: {
+    path: ':countryAndLanguage'
+    data: ParentData
+    home: {
+      path: ''
+      data: LeafData
+    }
+  }
+  plain: {
+    path: 'plain'
+    child: {
+      path: ''
+    }
+  }
+}, 'countryAndLanguage'>
+
+type RootDeclarations = Assert<Equal<
+  RouteDataDeclarations<TestRouteMap['root']>,
+  readonly [undefined]
+>>
+
+type ParentDeclarations = Assert<Equal<
+  RouteDataDeclarations<TestRouteMap['app']>,
+  readonly [ParentData]
+>>
+
+type LeafDeclarations = Assert<Equal<
+  RouteDataDeclarations<TestRouteMap['app']['home']>,
+  readonly [ParentData, LeafData]
+>>
+
+type LeafParams = Assert<Equal<
+  Parameters<TestRouteMap['app']['home']>,
+  [{ countryAndLanguage: string }]
+>>
+
+type MissingDataStaysUndefined = Assert<Equal<
+  RouteDataDeclarations<TestRouteMap['plain']['child']>,
+  readonly [undefined, undefined]
+>>
+
+export type RouteTypeAssertions = {
+  rootDeclarations: RootDeclarations
+  parentDeclarations: ParentDeclarations
+  leafDeclarations: LeafDeclarations
+  leafParams: LeafParams
+  missingDataStaysUndefined: MissingDataStaysUndefined
+}

--- a/type-tests/route-data-declarations.ts
+++ b/type-tests/route-data-declarations.ts
@@ -1,4 +1,4 @@
-import type { AsRouteMap, RouteDataDeclarations } from '../src/types.ts'
+import type { AsRouteMap, Route, RouteDataDeclarations } from '../src/types.ts'
 
 type Equal<A, B> =
   (<T>() => T extends A ? 1 : 2) extends
@@ -6,6 +6,7 @@ type Equal<A, B> =
 type Assert<T extends true> = T
 
 type ParentData = { parent: 'parent' }
+type SectionData = { section: 'section' }
 type LeafData = { leaf: 'leaf' }
 
 type TestRouteMap = AsRouteMap<{
@@ -17,12 +18,25 @@ type TestRouteMap = AsRouteMap<{
       path: ''
       data: LeafData
     }
+    stringLeaf: 'string/:slug'
+    section: {
+      path: 'section'
+      data: SectionData
+      detail: {
+        path: ':id'
+        data: LeafData
+      }
+    }
   }
   plain: {
     path: 'plain'
     child: {
       path: ''
     }
+  }
+  explicitlyUndefined: {
+    path: 'explicitly-undefined'
+    data: undefined
   }
 }, 'countryAndLanguage'>
 
@@ -46,9 +60,66 @@ type LeafParams = Assert<Equal<
   [{ countryAndLanguage: string }]
 >>
 
+type OwnDataIsPreserved = Assert<Equal<
+  TestRouteMap['app']['home']['data'],
+  LeafData
+>>
+
+type StringChildDeclarations = Assert<Equal<
+  RouteDataDeclarations<TestRouteMap['app']['stringLeaf']>,
+  readonly [ParentData, undefined]
+>>
+
+type StringChildDataIsUndefined = Assert<Equal<
+  TestRouteMap['app']['stringLeaf']['data'],
+  undefined
+>>
+
+type StringChildParamsIncludeAncestors = Assert<Equal<
+  Parameters<TestRouteMap['app']['stringLeaf']>,
+  [{ countryAndLanguage: string, slug: string }]
+>>
+
+type DeepDeclarationsStayOrdered = Assert<Equal<
+  RouteDataDeclarations<TestRouteMap['app']['section']['detail']>,
+  readonly [ParentData, SectionData, LeafData]
+>>
+
+type DeepParamsIncludeAncestors = Assert<Equal<
+  Parameters<TestRouteMap['app']['section']['detail']>,
+  [{ countryAndLanguage: string, id: string }]
+>>
+
 type MissingDataStaysUndefined = Assert<Equal<
   RouteDataDeclarations<TestRouteMap['plain']['child']>,
   readonly [undefined, undefined]
+>>
+
+type ExplicitUndefinedStaysUndefined = Assert<Equal<
+  RouteDataDeclarations<TestRouteMap['explicitlyUndefined']>,
+  readonly [undefined]
+>>
+
+type ParameterlessGeneratedRouteSatisfiesPublicRoute = Assert<
+  TestRouteMap['root'] extends Route ? true : false
+>
+
+type PublicRouteHasNoInventedAncestry = Assert<Equal<
+  RouteDataDeclarations<Route>,
+  readonly []
+>>
+
+type UnrelatedObjectsHaveNoAncestry = Assert<Equal<
+  RouteDataDeclarations<{ data: ParentData }>,
+  readonly []
+>>
+
+type RouteUnionsPreserveEachChain = Assert<Equal<
+  RouteDataDeclarations<
+    TestRouteMap['app']['home'] |
+    TestRouteMap['app']['stringLeaf']
+  >,
+  readonly [ParentData, LeafData] | readonly [ParentData, undefined]
 >>
 
 export type RouteTypeAssertions = {
@@ -56,5 +127,16 @@ export type RouteTypeAssertions = {
   parentDeclarations: ParentDeclarations
   leafDeclarations: LeafDeclarations
   leafParams: LeafParams
+  ownDataIsPreserved: OwnDataIsPreserved
+  stringChildDeclarations: StringChildDeclarations
+  stringChildDataIsUndefined: StringChildDataIsUndefined
+  stringChildParamsIncludeAncestors: StringChildParamsIncludeAncestors
+  deepDeclarationsStayOrdered: DeepDeclarationsStayOrdered
+  deepParamsIncludeAncestors: DeepParamsIncludeAncestors
   missingDataStaysUndefined: MissingDataStaysUndefined
+  explicitUndefinedStaysUndefined: ExplicitUndefinedStaysUndefined
+  parameterlessGeneratedRouteSatisfiesPublicRoute: ParameterlessGeneratedRouteSatisfiesPublicRoute
+  publicRouteHasNoInventedAncestry: PublicRouteHasNoInventedAncestry
+  unrelatedObjectsHaveNoAncestry: UnrelatedObjectsHaveNoAncestry
+  routeUnionsPreserveEachChain: RouteUnionsPreserveEachChain
 }

--- a/type-tests/route-data-declarations.ts
+++ b/type-tests/route-data-declarations.ts
@@ -104,6 +104,16 @@ type ParameterlessGeneratedRouteSatisfiesPublicRoute = Assert<
   TestRouteMap['root'] extends Route ? true : false
 >
 
+type ParameterizedGeneratedRouteSatisfiesPublicRoute = Assert<
+  TestRouteMap['app']['home'] extends Route ? true : false
+>
+
+type KeepConcreteRoute<R extends Route> = R
+type RouteConstraintPreservesParameters = Assert<Equal<
+  Parameters<KeepConcreteRoute<TestRouteMap['app']['home']>>,
+  [{ countryAndLanguage: string }]
+>>
+
 type PublicRouteHasNoInventedAncestry = Assert<Equal<
   RouteDataDeclarations<Route>,
   readonly []
@@ -136,6 +146,8 @@ export type RouteTypeAssertions = {
   missingDataStaysUndefined: MissingDataStaysUndefined
   explicitUndefinedStaysUndefined: ExplicitUndefinedStaysUndefined
   parameterlessGeneratedRouteSatisfiesPublicRoute: ParameterlessGeneratedRouteSatisfiesPublicRoute
+  parameterizedGeneratedRouteSatisfiesPublicRoute: ParameterizedGeneratedRouteSatisfiesPublicRoute
+  routeConstraintPreservesParameters: RouteConstraintPreservesParameters
   publicRouteHasNoInventedAncestry: PublicRouteHasNoInventedAncestry
   unrelatedObjectsHaveNoAncestry: UnrelatedObjectsHaveNoAncestry
   routeUnionsPreserveEachChain: RouteUnionsPreserveEachChain


### PR DESCRIPTION
## Summary

Preserve every route's root-to-leaf `data` declarations in the type produced by `AsRouteMap`, then expose that tuple through `RouteDataDeclarations<Route>`.

This is type metadata only. Route objects and reverse routing do not change at runtime. The broad public `Route` constraint is also corrected so generated routes with required parameters can satisfy generic route APIs without losing their exact signatures.

## Why

A typed route currently retains its own `data` declaration but has no type-level reference to its parents. Consumers can therefore infer leaf data, but not inherited route data such as application settings, menus, or breadcrumbs.

`@kaliber/sanity-routing` needs the complete declaration chain to model the data that its runtime handlers actually merge from root to leaf. Keeping the ancestry in `@kaliber/routing` is the smallest reusable change because this package is where the nested route map is converted into route types.

## What changed

- Add private unique-symbol metadata to the route type generated by `AsRouteMap`.
- Record a readonly root-to-leaf tuple of `data` declarations while recursively building the route map.
- Export `RouteDataDeclarations<Route>` for consumers that need the declaration chain.
- Introduce a named `RouteCallable` constraint that accepts both parameterless and required-parameter generated routes while leaving their inferred signatures intact.
- Preserve missing `data` as `undefined` instead of widening it to `any`.
- Add 18 focused compile-time assertions for exact own data, root-to-leaf ordering, deep and string-child routes, inherited parameters, missing and explicit `undefined`, metadata fallbacks, route unions, and public parameterless-route compatibility.
- Prepare the additive release as `@kaliber/routing` 4.1.0.

The metadata symbol is intentionally private: consumers can read the tuple through the exported utility type without gaining a runtime field or a symbol they can construct.

## Compatibility

- No runtime files change.
- Existing `asRouteMap` calls require no migration.
- The broad `Route` callable constraint now accepts every generated route; `AsRouteMap` still exposes each route's exact required parameters.
- Existing consumers that do not use `RouteDataDeclarations` see no behavioral change.

## Verification

- `pnpm exec tsc -p tsconfig.types.json --pretty false`
- `npm test`
- `git diff --check`

The type fixture contains 18 compile-time contract assertions, including required-parameter assignability and preservation through a generic `R extends Route` constraint. An isolated checkout containing only the PR commits passes all 69 existing runtime tests, so unrelated local routing tests are not part of this evidence.

All pass locally.

## Related PRs and merge order

This is PR 1 of 3:

1. **This PR** adds the route declaration-chain contract and should merge/release first as `@kaliber/routing` 4.1.0.
2. [Kaliber/kaliber-sanity-routing#50](https://github.com/Kaliber/kaliber-sanity-routing/pull/50) consumes that contract to infer complete runtime-equivalent route data and should release second as 12.1.0.
3. [Kaliber/rabobank-jobs#1741](https://github.com/Kaliber/rabobank-jobs/pull/1741) supplies Sanity TypeGen query literals and validates the result in a real application; it can replace its temporary local dependency after the first two releases.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added route metadata types that preserve data declarations across nested routes.
  * Exposed route data declaration information for improved TypeScript type inference.
  * Routes without declared data now explicitly reflect an undefined data value.

* **Tests**
  * Added compile-time coverage for nested route data declarations and parameter inference.

* **Chores**
  * Updated the package version to 4.1.0.
  * Added TypeScript configuration for type checking and type tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

