### PR TITLE
feat: route active-state and correlated route matching

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 export { asRouteMap, pick, pickRoute, asRouteChain, routeSymbol } from './src/routeMap'
 export {
-  useNavigate, usePick, useRouting, useLocationMatch,
+  useNavigate, usePick, useRouteActive, useRouting, useLocationMatch,
   useLocation, useHistory,
   Link, LocationProvider, StaticLocationProvider,
 } from './src/routing'

--- a/readme.md
+++ b/readme.md
@@ -213,6 +213,7 @@ There are a few methods used for matching routes, some are used on the client, o
   - `useRouting` (with `matchRoute` and `matchRoutes`)
   - `useLocationMatch`
   - `usePick` (with `pick`)
+  - `useRouteActive`
 
 ---
 ### `pickRoute`
@@ -266,10 +267,32 @@ Similar to `pickRoute` it returns the matched `Route` with it's `params` when a 
 ### `usePick`
 
 ```js
-function usePick(): (...routes: Array<Route>) => Route
+function usePick(): <R extends Route>(...routes: Array<R>) => { route: R, params: RouteParams<R> } | null
 ```
 
 Returns a function that lets you choose a route from an array of routes, or `null` if nothing matched. The selected route is found by traversing the parents of the picked route (`useLocationMatch`).
+
+The selected route and its parameters remain correlated. Narrowing `result.route` therefore narrows `result.params` to the parameters accepted by that route.
+
+---
+### `useRouteActive`
+
+```js
+function useRouteActive<R extends Route>(route: R, {
+  exact?: boolean,
+  params?: Partial<RouteParams<R>>,
+} = {}): boolean
+```
+
+Reports whether `route` is the current route or one of its ancestors. Set `exact` to only match the current route. Supply `params` to require some or all of that route's parameters to match as well.
+
+```js
+const jobsSectionIsActive = useRouteActive(routeMap.app.jobs)
+const dutchJobsAreActive = useRouteActive(
+  routeMap.app.jobs,
+  { params: { language: 'nl' } }
+)
+```
 
 ---
 ---
@@ -377,7 +400,5 @@ Reverse routing is missing in most routing libraries.
 
 - Why is the route map itself not a route?
   - It would make it impossible to have home as a route that is not the parent of any other routes. This makes some data fetching patterns impossible.
-
-
 
 

--- a/src/routeMatch.js
+++ b/src/routeMatch.js
@@ -1,0 +1,57 @@
+import { routeSymbol } from './routeMap.js'
+/** @import { Route, RouteActiveOptions, RouteMatch } from './types.ts' */
+
+/**
+ * Finds the nearest requested route in the current root-to-leaf match.
+ *
+ * @template {Route} R
+ * @param {{ params: object, route: Route } | null} locationMatch
+ * @param {R[]} routes
+ * @returns {RouteMatch<R> | null}
+ */
+export function pickMatchedRoute(locationMatch, routes) {
+  if (!locationMatch) return null
+
+  const requestedRoutes = new Set(routes.map((route, index) => {
+    if (!route) throw new Error(`Route missing at index ${index}`)
+    return route
+  }))
+
+  const route = findRequestedRoute(locationMatch.route, requestedRoutes)
+  return route
+    ? /** @type {RouteMatch<R>} */ ({ params: locationMatch.params, route })
+    : null
+}
+
+/**
+ * @template {Route} R
+ * @param {{ params: object, route: Route } | null} locationMatch
+ * @param {R} route
+ * @param {RouteActiveOptions<R>} [options]
+ */
+export function routeIsActive(locationMatch, route, { exact = false, params = undefined } = {}) {
+  if (!locationMatch) return false
+
+  const matchesRoute = exact
+    ? locationMatch.route === route
+    : Boolean(pickMatchedRoute(locationMatch, [route]))
+
+  return matchesRoute && (!params || objectIncludes(locationMatch.params, params))
+}
+
+/**
+ * @template {Route} R
+ * @param {Route} route
+ * @param {Set<R>} requestedRoutes
+ * @returns {R | null}
+ */
+function findRequestedRoute(route, requestedRoutes) {
+  if (requestedRoutes.has(/** @type {R} */ (route))) return /** @type {R} */ (route)
+
+  const parent = route[routeSymbol].parent
+  return parent ? findRequestedRoute(parent, requestedRoutes) : null
+}
+
+function objectIncludes(value, subset) {
+  return Object.entries(subset).every(([key, expected]) => value[key] === expected)
+}

--- a/src/routeMatch.test.js
+++ b/src/routeMatch.test.js
@@ -1,0 +1,69 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+import { asRouteMap, pickRoute } from './routeMap.js'
+import { pickMatchedRoute, routeIsActive } from './routeMatch.js'
+
+const routeMap = asRouteMap({
+  root: '',
+  app: {
+    path: ':language',
+    overview: {
+      path: 'articles',
+      article: ':slug',
+    },
+    contact: 'contact',
+  },
+})
+
+const articleMatch = pickRoute('/nl/articles/example/', routeMap)
+
+describe('pickMatchedRoute', () => {
+  test('returns the nearest requested route with the current parameters', () => {
+    assert.deepEqual(
+      pickMatchedRoute(articleMatch, [routeMap.app, routeMap.app.overview]),
+      {
+        route: routeMap.app.overview,
+        params: { language: 'nl', slug: 'example' },
+      }
+    )
+  })
+
+  test('returns null without a current or requested route match', () => {
+    assert.equal(pickMatchedRoute(null, [routeMap.app]), null)
+    assert.equal(pickMatchedRoute(articleMatch, [routeMap.app.contact]), null)
+  })
+
+  test('keeps the existing missing-route error', () => {
+    assert.throws(
+      () => pickMatchedRoute(articleMatch, [undefined]),
+      /Route missing at index 0/
+    )
+  })
+})
+
+describe('routeIsActive', () => {
+  test('matches an active ancestor by default', () => {
+    assert.equal(routeIsActive(articleMatch, routeMap.app.overview), true)
+  })
+
+  test('can require an exact route', () => {
+    assert.equal(routeIsActive(articleMatch, routeMap.app.overview, { exact: true }), false)
+    assert.equal(routeIsActive(articleMatch, routeMap.app.overview.article, { exact: true }), true)
+  })
+
+  test('matches only the supplied parameters', () => {
+    assert.equal(
+      routeIsActive(articleMatch, routeMap.app.overview, { params: { language: 'nl' } }),
+      true
+    )
+    assert.equal(
+      routeIsActive(articleMatch, routeMap.app.overview, { params: { language: 'en' } }),
+      false
+    )
+  })
+
+  test('rejects siblings and missing matches', () => {
+    assert.equal(routeIsActive(articleMatch, routeMap.app.contact), false)
+    assert.equal(routeIsActive(null, routeMap.app), false)
+  })
+})

--- a/src/routing.js
+++ b/src/routing.js
@@ -1,7 +1,9 @@
 
 import { getHistory } from './history.js'
 import { callOrReturn } from './utils.js'
-import { pickRoute, routeSymbol } from './routeMap.js'
+import { pickRoute } from './routeMap.js'
+import { pickMatchedRoute, routeIsActive } from './routeMatch.js'
+/** @import { Route, RouteActiveOptions, RouteMap, RouteMatch } from './types.ts' */
 
 // Why so many contexts? Information should be grouped in a context based on the rate of change.
 /** @type {React.Context<null | { params: object, route: Route }>}*/
@@ -76,33 +78,26 @@ export function useHistory() {
   function DoNotUseHistoryOnServerSide() {}
 }
 
+/** @returns {<R extends Route>(...routes: R[]) => RouteMatch<R> | null} */
 export function usePick() {
   const locationMatch = useLocationMatch()
 
   return React.useCallback(
-    (...routes) => {
-      if (!locationMatch) return null
-
-      const { params, route } = locationMatch
-      const availableRoutes = new Map(
-        routes.map((route, i) => {
-          if (!route) throw new Error(`Route missing at index ${i}`)
-          return [route, route]
-        })
-      )
-      return selectRoute(route, params)
-
-      function selectRoute(route, params) {
-        const { parent } = route[routeSymbol]
-        return (
-          availableRoutes.has(route) ? { params, route: availableRoutes.get(route) } :
-          parent ? selectRoute(parent, params) :
-          null
-        )
-      }
-    },
+    /** @type {<R extends Route>(...routes: R[]) => RouteMatch<R> | null} */
+    ((...routes) => pickMatchedRoute(locationMatch, routes)),
     [locationMatch]
   )
+}
+
+/**
+ * Reports whether a route is the current route or one of its ancestors.
+ *
+ * @template {Route} R
+ * @param {R} route
+ * @param {RouteActiveOptions<R>} [options]
+ */
+export function useRouteActive(route, options) {
+  return routeIsActive(useLocationMatch(), route, options)
 }
 
 export function LocationProvider({
@@ -263,8 +258,3 @@ function shouldNavigate(e) {
     !(e.metaKey || e.altKey || e.ctrlKey || e.shiftKey)
   )
 }
-
-/**
- * @typedef {import('./types.ts').Route} Route
- * @typedef {import('./types.ts').RouteMap} RouteMap
- */

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,6 +13,18 @@ type RouteCallable = (...parameters: any[]) => string
 
 export type RouteMap = { [routeMapSymbol]: any }
 export type Route = RouteCallable & RouteProps & { [routeSymbol]: any }
+/** Parameters accepted by a generated reverse route. */
+export type RouteParams<R extends Route> =
+  Parameters<R> extends [] ? {} :
+  Parameters<R> extends [infer Params] ? Params : never
+/** A route and the parameters captured while matching it. */
+export type RouteMatch<R extends Route> = R extends Route
+  ? { params: RouteParams<R>, route: R }
+  : never
+export type RouteActiveOptions<R extends Route> = {
+  exact?: boolean
+  params?: Partial<RouteParams<R>>
+}
 /** The root-to-route `data` declarations retained by `AsRouteMap`. */
 export type RouteDataDeclarations<R> =
   R extends RouteTypeMetadata<infer DataDeclarations> ? DataDeclarations : readonly []

--- a/type-tests/route-data-declarations.ts
+++ b/type-tests/route-data-declarations.ts
@@ -1,4 +1,11 @@
-import type { AsRouteMap, Route, RouteDataDeclarations } from '../src/types.ts'
+import type {
+  AsRouteMap,
+  Route,
+  RouteActiveOptions,
+  RouteDataDeclarations,
+  RouteMatch,
+  RouteParams,
+} from '../src/types.ts'
 
 type Equal<A, B> =
   (<T>() => T extends A ? 1 : 2) extends
@@ -90,6 +97,33 @@ type DeepParamsIncludeAncestors = Assert<Equal<
   [{ countryAndLanguage: string, id: string }]
 >>
 
+type ParameterlessRouteParamsAreEmpty = Assert<Equal<
+  RouteParams<TestRouteMap['root']>,
+  {}
+>>
+
+type ParameterizedRouteParamsAreExact = Assert<Equal<
+  RouteParams<TestRouteMap['app']['section']['detail']>,
+  { countryAndLanguage: string, id: string }
+>>
+
+type RouteMatchKeepsRouteAndParamsCorrelated = Assert<Equal<
+  RouteMatch<TestRouteMap['app']['home'] | TestRouteMap['app']['stringLeaf']>,
+  | {
+    route: TestRouteMap['app']['home']
+    params: { countryAndLanguage: string }
+  }
+  | {
+    route: TestRouteMap['app']['stringLeaf']
+    params: { countryAndLanguage: string, slug: string }
+  }
+>>
+
+type ActiveRouteParamsArePartial = Assert<Equal<
+  NonNullable<RouteActiveOptions<TestRouteMap['app']['section']['detail']>['params']>,
+  { countryAndLanguage?: string, id?: string }
+>>
+
 type MissingDataStaysUndefined = Assert<Equal<
   RouteDataDeclarations<TestRouteMap['plain']['child']>,
   readonly [undefined, undefined]
@@ -143,6 +177,10 @@ export type RouteTypeAssertions = {
   stringChildParamsIncludeAncestors: StringChildParamsIncludeAncestors
   deepDeclarationsStayOrdered: DeepDeclarationsStayOrdered
   deepParamsIncludeAncestors: DeepParamsIncludeAncestors
+  parameterlessRouteParamsAreEmpty: ParameterlessRouteParamsAreEmpty
+  parameterizedRouteParamsAreExact: ParameterizedRouteParamsAreExact
+  routeMatchKeepsRouteAndParamsCorrelated: RouteMatchKeepsRouteAndParamsCorrelated
+  activeRouteParamsArePartial: ActiveRouteParamsArePartial
   missingDataStaysUndefined: MissingDataStaysUndefined
   explicitUndefinedStaysUndefined: ExplicitUndefinedStaysUndefined
   parameterlessGeneratedRouteSatisfiesPublicRoute: ParameterlessGeneratedRouteSatisfiesPublicRoute


### PR DESCRIPTION
Stacked on #18 (`typed-route-data-chain`). Base is `typed-route-data-chain`, so this diff only shows the route-matching work.

Supersedes #12, open since October 2023, which set out to solve the same problem.

## What this does

Adds `useRouteActive`, and makes `usePick` return a correlated route/params pair instead of a loosely typed one.

```js
function useRouteActive<R extends Route>(route: R, {
  exact?: boolean,
  params?: Partial<RouteParams<R>>,
} = {}): boolean
```

- By default it reports whether `route` is the current route **or one of its ancestors** — the question a nav item actually asks.
- `exact: true` narrows to the current route only.
- `params` requires some or all of that route's parameters to match too.

```js
const jobsSectionIsActive = useRouteActive(routeMap.app.jobs)
const dutchJobsAreActive = useRouteActive(routeMap.app.jobs, { params: { language: 'nl' } })
```

The matching logic moves out of the hook into `src/routeMatch.js` as two plain functions — `pickMatchedRoute` and `routeIsActive` — and `usePick` is rewritten to call the first one.

Three new types in `src/types.ts`: `RouteParams<R>`, `RouteMatch<R>`, `RouteActiveOptions<R>`.

## Why it's needed

Active state is the most common thing a consumer asks the router, and there is currently no answer for it. Every app writes this, which is also what `example/src/advanced/App.js:145` does today:

```js
const { params, route: currentRoute } = useLocationMatch()
const isActive = route === currentRoute
```

That line has three problems, and they are not stylistic:

1. **It only matches the leaf.** On `/nl/articles/example`, a nav item for `routeMap.app.overview` is not active — even though the user is plainly inside the articles section. Highlighting a section in a nav is *the* use case, and identity comparison can't express it. Getting ancestor matching requires walking `route[routeSymbol].parent` by hand, which means reaching for the symbol the library exports for its own internals.
2. **It destructures a nullable value.** `useLocationMatch()` returns `null` when nothing matched, so this throws on a 404 page. Every call site has to remember the guard, and the one that forgets fails only on the route nobody tests.
3. **Params comparison is hand-rolled.** "Active, but only for `language: 'nl'`" becomes an ad-hoc `Object.entries` loop, written slightly differently in each project.

`usePick` already contains a correct ancestor walk — it has since the internals rewrite in #16. The capability is in the library; it just isn't reachable unless what you want is a *pick*. `useRouteActive` exposes what's already there.

## Why the changes make sense

**Ancestor matching is the default, exact is the opt-in.** This is the choice worth arguing about, so: the common case is a nav item or breadcrumb that should stay lit while the user is anywhere beneath it. Making that the default means the frequent case is `useRouteActive(route)` and the rare case says so explicitly. The inverse default would leave the current bug — a section that unlights when you open a detail page — as the thing you get by writing the obvious call.

**Extraction to `routeMatch.js` is what makes it testable.** The ancestor walk used to be a closure inside a `useCallback` inside a hook, reachable only by rendering a component with a provider. As `pickMatchedRoute(locationMatch, routes)` it takes a plain match object and returns a plain result, so `src/routeMatch.test.js` drives it with `pickRoute('/nl/articles/example/', routeMap)` — no React, no renderer, no provider. The 7 new tests exist because of this move; they were not practical to write before.

**`usePick` and `useRouteActive` share one traversal.** Two independent ancestor walks would be two things to keep in agreement about what "active" means. `routeIsActive` calls `pickMatchedRoute` for the non-exact case, so there is exactly one definition.

**The pure functions stay internal.** Only the hooks are added to `index.js`. `pickMatchedRoute` and `routeIsActive` are exported from their module for the tests, not from the package — this doesn't widen the public API surface to two functions that need a `locationMatch` nobody outside the library holds.

**`RouteMatch<R>` is distributive, and that's the point.** Written as `R extends Route ? { params: RouteParams<R>, route: R } : never`, a union of routes becomes a union of *pairs* rather than one object with a union in each field. So narrowing `result.route` narrows `result.params` to the params that route actually accepts:

```js
const result = pick(routeMap.app.home, routeMap.app.article)
if (result.route === routeMap.app.article) result.params.slug // exists here, and only here
```

Without distribution, `params` would be the union of both shapes and `slug` would be an error on the branch where it is guaranteed to be present.

**`params` is `Partial<RouteParams<R>>`, not the full set.** Requiring every param would make the option useless for the case it exists for — "am I in the Dutch section" shouldn't force you to also name the article slug. `objectIncludes` checks only the keys you supplied.

**Nothing breaks.** `usePick`'s runtime behavior is unchanged, including the `Route missing at index N` error, which has a test pinning it. The rewrite is a delegation, and the type annotation it gains is more precise than the implicit one it had. `useRouteActive` is purely additive.

## Perks

- **Nav highlighting works on nested routes** without touching `routeSymbol` or writing a parent walk per project.
- **No null-guard at the call site.** `useRouteActive` returns `false` when nothing matched, so 404 pages stop being a special case.
- **Param-scoped active state** is a built-in option rather than an ad-hoc comparison.
- **`usePick` results are properly typed** — narrowing the route narrows the params, so the common `pick`-then-branch pattern stops needing casts.
- **The traversal is unit-testable**, so future changes to matching are cheap to verify.
- **One definition of "active"** shared by both hooks.
- Zero new dependencies; no change required for any existing caller.

## Verification

- `src/routeMatch.test.js` — 7 `node:test` cases: nearest-ancestor pick with current params, null on no-match and on unrequested-route, the preserved missing-route error, default ancestor matching, `exact` behavior in both directions, partial-param matching in both directions, and sibling/null rejection.
- Full suite: **76 tests, 76 pass** on this branch.
- `type-tests/route-data-declarations.ts` gains 4 assertions: empty params for a parameterless route, exact params for a parameterized one, `RouteMatch` distribution over a route union, and `params` being partial. `tsc -p tsconfig.types.json` is clean.

## Known gaps

- `useRouteActive` itself has no rendering test — it's a one-line composition of `useLocationMatch()` and `routeIsActive`, and the second is fully covered, but the wiring is asserted only by the type tests.
- `example/src/advanced/App.js:145` still hand-rolls `route === currentRoute`. Left alone deliberately to keep this diff to the library; worth updating as the first consumer of the new hook.
- `RouteParams<R>` resolves to `never` for a callable taking two or more arguments. Generated routes always take a single params object or none, so this is unreachable today — noting it in case route generation ever changes.

Opened as a draft: it stacks on a draft-stage chain, and #12 should get a decision before this lands.
